### PR TITLE
Fix evaluation import when COCO not installed

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,4 @@ Icon
 Network Trash Folder
 Temporary Items
 .apdisk
+!requirements.txt

--- a/README.md
+++ b/README.md
@@ -65,8 +65,8 @@ The code structure follows Detectron2 v0.1.* and fsdet.
   - **structures**: Data types, such as bounding boxes and image lists.
   - **utils**: Utility functions.
 - **tools**
-  - **train_net.py**: Training script.
-  - **test_net.py**: Testing script.
+  - **train_net.py**: Training script. Use `--show-config` to print the final configuration.
+  - **test_net.py**: Testing script. Also supports `--show-config`.
   - **ckpt_surgery.py**: Surgery on checkpoints.
   - **run_experiments.py**: Running experiments across many seeds.
   - **aggregate_seeds.py**: Aggregating results from many seeds.
@@ -138,3 +138,4 @@ bash scripts/train_fsod.sh 1 10 ./checkpoints/fsod 2800 1000 1
 ```
 The last two numbers override `SOLVER.MAX_ITER` for stage 1 and stage 2,
 while the final number selects how many GPUs to use. Adjust them as needed to run only a few epochs.
+Append `--show-config` to any of these commands if you want to print the merged configuration.

--- a/README.md
+++ b/README.md
@@ -10,11 +10,14 @@ FsDet is built on [Detectron2](https://github.com/facebookresearch/detectron2). 
 **Dependencies**
 
 * Linux with Python >= 3.6
-* [PyTorch](https://pytorch.org/get-started/locally/) >= 1.3 
-* [torchvision](https://github.com/pytorch/vision/) that matches the PyTorch installation
-* Dependencies: ```pip install -r requirements.txt```
+* [PyTorch](https://pytorch.org/get-started/locally/) >= 1.3 and
+  [torchvision](https://github.com/pytorch/vision/) that matches the PyTorch installation.
+  Install PyTorch first before running the commands below.
+* Install this package and dependencies: ```pip install -e .```
+* Or install dependencies from `requirements.txt`: `pip install -r requirements.txt`
 * pycocotools: ```pip install cython; pip install 'git+https://github.com/cocodataset/cocoapi.git#subdirectory=PythonAPI'```
-* [fvcore](https://github.com/facebookresearch/fvcore/): ```pip install 'git+https://github.com/facebookresearch/fvcore'``` 
+* [albumentations](https://github.com/albumentations-team/albumentations) (optional, for AlbumentationMapper): `pip install albumentations`
+* [fvcore](https://github.com/facebookresearch/fvcore/): ```pip install 'git+https://github.com/facebookresearch/fvcore'```
 * [OpenCV](https://pypi.org/project/opencv-python/), optional, needed by demo and visualization ```pip install opencv-python```
 * GCC >= 4.9
 
@@ -38,7 +41,8 @@ Our experiments are conducted on two datasets: PASCAL VOC and X-ray FSOD.
 
 
 - X-ray FSOD: We use the train set of X-ray FSOD for training and the test set of X-ray FSOD for evaluation. We randomly split the 20 object classes into 15 base classes and 5 novel classes, and we consider 3 random splits. The splits can be found in [fsdet/data/datasets/builtin_meta.py](fsdet/data/datasets/builtin_meta.py).
-(Note that in this repository, **the X-ray FSOD dataset is named RFS**). The default seed of X-ray FSOD that is used to report performace in research papers can be found in the folder: Xray FSOD/train/split.(Download Link: If you want to access the dataset, please sign the <a href="./Commitment.pdf">PDF</a> file and send it to cvresearcher@163.com. After receiving your request, we will rely with the download link soon.)
+(Note that in this repository, **the X-ray FSOD dataset is named RFS**). Place the dataset under `~/FSOD` to match the default path used by the code. If you store it elsewhere, update `fsdet/data/datasets/builtin.py` and `fsdet/data/datasets/meta_rfs.py` accordingly.
+(The default seed of X-ray FSOD that is used to report performance in research papers can be found in the folder: Xray FSOD/train/split. Download link: sign the <a href="./Commitment.pdf">PDF</a> file and send it to cvresearcher@163.com. After receiving your request, we will reply with the link.)
 
 
 ## Code Structure
@@ -119,4 +123,18 @@ Where `WEIGHTS_PATH` points to the model parameters generated from the training 
 
 Or you can specify `TEST.EVAL_PERIOD` in the configuation yml to evaluate during training. 
 
-The whole procedure can be seen in run_rfs.sh and run_voc.sh
+The whole procedure can be seen in `run_rfs.sh` and `run_voc.sh`.
+If you only want to train with the FSOD dataset, run `bash run_rfs.sh` or use any
+configuration under `configs/RFS`. The VOC dataset and script are not required
+in this case. For a quick single experiment you can also execute
+`scripts/train_fsod.sh`, which performs base training, weight initialization and
+fine-tuning for a given split and shot. The script accepts optional arguments for
+the output directory and the number of iterations:
+
+```bash
+# Train split 1 with 10 shots, writing checkpoints under ./checkpoints/fsod
+# Limit the base and fine-tuning stages to 2 epochs (approximately)
+bash scripts/train_fsod.sh 1 10 ./checkpoints/fsod 2800 1000
+```
+The last two numbers override `SOLVER.MAX_ITER` for stage 1 and stage 2
+respectively. Adjust them as needed to run only a few epochs.

--- a/README.md
+++ b/README.md
@@ -129,12 +129,12 @@ configuration under `configs/RFS`. The VOC dataset and script are not required
 in this case. For a quick single experiment you can also execute
 `scripts/train_fsod.sh`, which performs base training, weight initialization and
 fine-tuning for a given split and shot. The script accepts optional arguments for
-the output directory and the number of iterations:
+the output directory, the number of iterations, and the GPU count:
 
 ```bash
 # Train split 1 with 10 shots, writing checkpoints under ./checkpoints/fsod
 # Limit the base and fine-tuning stages to 2 epochs (approximately)
-bash scripts/train_fsod.sh 1 10 ./checkpoints/fsod 2800 1000
+bash scripts/train_fsod.sh 1 10 ./checkpoints/fsod 2800 1000 1
 ```
-The last two numbers override `SOLVER.MAX_ITER` for stage 1 and stage 2
-respectively. Adjust them as needed to run only a few epochs.
+The last two numbers override `SOLVER.MAX_ITER` for stage 1 and stage 2,
+while the final number selects how many GPUs to use. Adjust them as needed to run only a few epochs.

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -22,6 +22,8 @@ def setup_cfg(args):
     cfg = get_cfg()
     cfg.merge_from_file(args.config_file)
     cfg.merge_from_list(args.opts or [])
+    if args.show_config:
+        print("Merged config:\n" + cfg.dump())
     # Set score_threshold for builtin models
     cfg.MODEL.RETINANET.SCORE_THRESH_TEST = args.confidence_threshold
     cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = args.confidence_threshold
@@ -50,6 +52,7 @@ def get_parser():
         help="A file or directory to save output visualizations. "
         "If not given, will show output in an OpenCV window.",
     )
+    parser.add_argument("--show-config", action="store_true", help="print the final config and exit")
 
     parser.add_argument(
         "--confidence-threshold",

--- a/demo/demo.py
+++ b/demo/demo.py
@@ -21,7 +21,7 @@ def setup_cfg(args):
     # load config from file and command-line arguments
     cfg = get_cfg()
     cfg.merge_from_file(args.config_file)
-    cfg.merge_from_list(args.opts)
+    cfg.merge_from_list(args.opts or [])
     # Set score_threshold for builtin models
     cfg.MODEL.RETINANET.SCORE_THRESH_TEST = args.confidence_threshold
     cfg.MODEL.ROI_HEADS.SCORE_THRESH_TEST = args.confidence_threshold

--- a/fsdet/data/dataset_mapper.py
+++ b/fsdet/data/dataset_mapper.py
@@ -5,7 +5,10 @@ import numpy as np
 import torch
 
 import json
-import albumentations as A
+try:
+    import albumentations as A  # optional dependency
+except ImportError:  # pragma: no cover - albumentations is not required unless used
+    A = None
 from fsdet.structures import BoxMode
 
 from . import detection_utils as utils
@@ -114,6 +117,11 @@ class DatasetMapper:
 class AlbumentationMapper:
     debug_count = 5
     def __init__(self, cfg, is_train=True):
+        if A is None:
+            raise ImportError(
+                "Albumentations is required for AlbumentationMapper."
+                " Install it via `pip install albumentations`."
+            )
         # use the detectron2 crop_gen
         if cfg.INPUT.CROP.ENABLED and is_train:
             self.crop_gen = T.RandomCrop(cfg.INPUT.CROP.TYPE, cfg.INPUT.CROP.SIZE)

--- a/fsdet/data/datasets/__init__.py
+++ b/fsdet/data/datasets/__init__.py
@@ -1,7 +1,19 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from .coco import load_coco_json
-from .lvis import load_lvis_json, register_lvis_instances
-from .register_coco import register_coco_instances
+try:
+    from .coco import load_coco_json
+except Exception:  # pragma: no cover - coco dataset is optional
+    load_coco_json = None
+
+try:
+    from .lvis import load_lvis_json, register_lvis_instances
+except Exception:  # pragma: no cover - lvis dataset is optional
+    pass
+
+try:
+    from .register_coco import register_coco_instances
+except Exception:  # pragma: no cover - coco dataset is optional
+    pass
+
 from . import builtin  # ensure the builtin datasets are registered
 
 

--- a/fsdet/data/datasets/builtin.py
+++ b/fsdet/data/datasets/builtin.py
@@ -331,5 +331,15 @@ if register_coco_instances is not None:
     register_all_coco()
 if register_lvis_instances is not None:
     register_all_lvis()
-register_all_pascal_voc()
-register_all_rfs()
+
+PASVOC_ROOT = "/media/datasets/PascalVOC_outline/VOCdevkit"
+try:
+    from pathlib import Path
+    if Path(PASVOC_ROOT).exists():
+        register_all_pascal_voc(PASVOC_ROOT)
+except Exception:
+    pass
+
+RFS_ROOT = os.path.expanduser("~/FSOD")
+if os.path.isdir(RFS_ROOT):
+    register_all_rfs(RFS_ROOT)

--- a/fsdet/data/datasets/builtin.py
+++ b/fsdet/data/datasets/builtin.py
@@ -20,10 +20,20 @@ To add new dataset, refer to the tutorial "docs/DATASETS.md".
 import os
 
 from fsdet.data import MetadataCatalog
-from .register_coco import register_coco_instances
-from .meta_coco import register_meta_coco
-from .lvis import register_lvis_instances
-from .meta_lvis import register_meta_lvis
+
+try:
+    from .register_coco import register_coco_instances
+    from .meta_coco import register_meta_coco
+except Exception:  # coco dataset is optional
+    register_coco_instances = None  # type: ignore
+    register_meta_coco = None  # type: ignore
+
+try:
+    from .lvis import register_lvis_instances
+    from .meta_lvis import register_meta_lvis
+except Exception:  # lvis dataset is optional
+    register_lvis_instances = None  # type: ignore
+    register_meta_lvis = None  # type: ignore
 from .pascal_voc import register_pascal_voc
 from .meta_pascal_voc import register_meta_pascal_voc
 from .rfs import register_rfs
@@ -52,6 +62,8 @@ _PREDEFINED_SPLITS_COCO["coco"] = {
 
 
 def register_all_coco(root="datasets"):
+    if register_coco_instances is None:
+        return
     for dataset_name, splits_per_dataset in _PREDEFINED_SPLITS_COCO.items():
         for key, (image_root, json_file) in splits_per_dataset.items():
             # Assume pre-defined datasets live in `./datasets`.
@@ -104,6 +116,8 @@ _PREDEFINED_SPLITS_LVIS = {
 
 
 def register_all_lvis(root="datasets"):
+    if register_lvis_instances is None:
+        return
     for dataset_name, splits_per_dataset in _PREDEFINED_SPLITS_LVIS.items():
         for key, (image_root, json_file) in splits_per_dataset.items():
             # Assume pre-defined datasets live in `./datasets`.
@@ -230,7 +244,7 @@ def register_all_pascal_voc(root="/media/datasets/PascalVOC_outline/VOCdevkit"):
         MetadataCatalog.get(name).evaluator_type = "pascal_voc"
 
 
-def register_all_rfs(root="/media/datasets/RFS"):
+def register_all_rfs(root=os.path.expanduser("~/FSOD")):
     SPLITS = [
         ("rfs_trainval", "train", "trainval"),
         ("rfs_test", "test", "test"),
@@ -313,7 +327,9 @@ def register_all_rfs(root="/media/datasets/RFS"):
         MetadataCatalog.get(name).evaluator_type = "rfs"
 
 # Register them all under "./datasets"
-register_all_coco()
-register_all_lvis()
+if register_coco_instances is not None:
+    register_all_coco()
+if register_lvis_instances is not None:
+    register_all_lvis()
 register_all_pascal_voc()
 register_all_rfs()

--- a/fsdet/data/datasets/meta_rfs.py
+++ b/fsdet/data/datasets/meta_rfs.py
@@ -9,6 +9,9 @@ import cv2
 from fsdet.structures import BoxMode
 from fsdet.data import DatasetCatalog, MetadataCatalog
 
+# Default location of the X-ray FSOD dataset
+RFS_ROOT = os.path.expanduser("~/FSOD")
+
 
 __all__ = ["register_meta_rfs"]
 
@@ -148,7 +151,7 @@ def load_filtered_rfs_instances(
     is_shots = "shot" in name
     if is_shots:
         fileids = {}
-        split_dir = os.path.join("/media/datasets/RFS/train", "split")
+        split_dir = os.path.join(RFS_ROOT, "train", "split")
 
         if use_more_base:
             ploidy = name.split('_')[-1]
@@ -191,7 +194,7 @@ def load_filtered_rfs_instances(
             dicts_ = []
             for fileid in fileids_:
                 #year = "2012" if "_" in fileid else "2007"
-                dirname = os.path.join("/media/datasets/RFS/train")
+                dirname = os.path.join(RFS_ROOT, "train")
                 anno_file = os.path.join(dirname, "annotations", fileid + ".txt")
                 jpeg_file = os.path.join(dirname, "images", fileid + ".jpg")
 

--- a/fsdet/data/transforms/transform.py
+++ b/fsdet/data/transforms/transform.py
@@ -6,6 +6,12 @@ import numpy as np
 from fvcore.transforms.transform import HFlipTransform, NoOpTransform, Transform
 from PIL import Image
 
+# PIL removed the LINEAR constant in favor of Resampling enums.
+try:  # Pillow>=10
+    _BILINEAR = Image.Resampling.BILINEAR
+except AttributeError:  # Pillow<10
+    _BILINEAR = Image.BILINEAR
+
 __all__ = ["ExtentTransform", "ResizeTransform"]
 
 
@@ -19,7 +25,7 @@ class ExtentTransform(Transform):
     See: https://pillow.readthedocs.io/en/latest/PIL.html#PIL.ImageTransform.ExtentTransform
     """
 
-    def __init__(self, src_rect, output_size, interp=Image.LINEAR, fill=0):
+    def __init__(self, src_rect, output_size, interp=_BILINEAR, fill=0):
         """
         Args:
             src_rect (x0, y0, x1, y1): src coordinates

--- a/fsdet/engine/defaults.py
+++ b/fsdet/engine/defaults.py
@@ -85,6 +85,11 @@ def default_argument_parser():
         default=0,
         help="the rank of this machine (unique per machine)",
     )
+    parser.add_argument(
+        "--show-config",
+        action="store_true",
+        help="print the final configuration and exit",
+    )
 
     # PyTorch still may leave orphan processes in multi-gpu training.
     # Therefore we use a deterministic way to obtain port,

--- a/fsdet/evaluation/__init__.py
+++ b/fsdet/evaluation/__init__.py
@@ -1,7 +1,16 @@
 # Copyright (c) Facebook, Inc. and its affiliates. All Rights Reserved
-from .coco_evaluation import COCOEvaluator
+try:
+    from .coco_evaluation import COCOEvaluator
+except Exception:  # pragma: no cover - coco dataset is optional
+    COCOEvaluator = None
+
 from .evaluator import DatasetEvaluator, DatasetEvaluators, inference_context, inference_on_dataset
-from .lvis_evaluation import LVISEvaluator
+
+try:
+    from .lvis_evaluation import LVISEvaluator
+except Exception:  # pragma: no cover - lvis dataset is optional
+    LVISEvaluator = None
+
 from .pascal_voc_evaluation import PascalVOCDetectionEvaluator
 from .rfs_evaluation import RFSDetectionEvaluator
 from .testing import print_csv_format, verify_results

--- a/fsdet/evaluation/testing.py
+++ b/fsdet/evaluation/testing.py
@@ -3,7 +3,11 @@ import logging
 import numpy as np
 import pprint
 import sys
-from collections import Mapping, OrderedDict
+try:
+    from collections.abc import Mapping
+except ImportError:  # Python<3.3
+    from collections import Mapping  # type: ignore
+from collections import OrderedDict
 
 
 def print_csv_format(results):

--- a/fsdet/modeling/contrastive_loss.py
+++ b/fsdet/modeling/contrastive_loss.py
@@ -1,0 +1,35 @@
+import torch
+from torch import nn
+
+class _BaseLoss(nn.Module):
+    def __init__(self, *args, **kwargs):
+        super().__init__()
+    def forward(self, *args, **kwargs):
+        raise NotImplementedError(
+            "Contrastive losses are optional and not implemented in this package."
+        )
+
+class SupConLoss(_BaseLoss):
+    pass
+
+class SupConLossV2(_BaseLoss):
+    pass
+
+class SupConLossWithPrototype(_BaseLoss):
+    pass
+
+class SupConLossWithStorage(_BaseLoss):
+    pass
+
+class ContrastiveHead(nn.Module):
+    """Simple two-layer MLP used when contrastive losses are enabled."""
+    def __init__(self, in_dim, out_dim):
+        super().__init__()
+        self.fc = nn.Sequential(
+            nn.Linear(in_dim, out_dim),
+            nn.ReLU(inplace=True),
+            nn.Linear(out_dim, out_dim),
+        )
+
+    def forward(self, x):
+        return self.fc(x)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,17 @@
+# Core dependencies
+termcolor>=1.1
+Pillow>=6.0
+yacs>=0.1.6
+tabulate
+cloudpickle
+matplotlib
+tqdm>4.29.0
+tensorboard
+imagesize
+# Optional utilities
+shapely
+psutil
+albumentations # optional
+opencv-python # optional
+fvcore @ git+https://github.com/facebookresearch/fvcore
+cython

--- a/scripts/train_fsod.sh
+++ b/scripts/train_fsod.sh
@@ -1,13 +1,15 @@
 #!/usr/bin/env bash
 # Simple training script for the FSOD dataset
-# Usage: bash scripts/train_fsod.sh [SPLIT] [SHOT] [OUTPUT_ROOT] [BASE_ITERS] [FINE_ITERS]
-# BASE_ITERS and FINE_ITERS optionally override SOLVER.MAX_ITER for the two stages
+# Usage: bash scripts/train_fsod.sh [SPLIT] [SHOT] [OUTPUT_ROOT] [BASE_ITERS] [FINE_ITERS] [NUM_GPUS]
+# BASE_ITERS and FINE_ITERS optionally override SOLVER.MAX_ITER for the two stages.
+# NUM_GPUS sets the number of GPUs used for training (default: 1).
 
 SPLIT=${1:-1}
 SHOT=${2:-10}
 OUTPUT_ROOT=${3:-./checkpoints/fsod}
 BASE_ITERS=${4:-0}
 FINE_ITERS=${5:-0}
+NUM_GPUS=${6:-1}
 
 FINE_EXTRA=""
 if [ "$FINE_ITERS" -gt 0 ]; then
@@ -20,7 +22,7 @@ if [ "$BASE_ITERS" -gt 0 ]; then
     BASE_EXTRA="SOLVER.MAX_ITER ${BASE_ITERS}"
 fi
 
-python tools/train_net.py --num-gpus 3 \
+python tools/train_net.py --num-gpus ${NUM_GPUS} \
     --config-file configs/RFS/base-training/R101_FPN_base_training_split${SPLIT}.yml \
     --opts OUTPUT_DIR ${OUTPUT_ROOT}/faster_rcnn_R_101_FPN_base${SPLIT} ${BASE_EXTRA}
 
@@ -31,7 +33,7 @@ python tools/ckpt_surgery.py \
     --save-dir ${OUTPUT_ROOT}/faster_rcnn_R_101_FPN_all${SPLIT}
 
 # Stage 2: fine-tune on novel data
-python tools/train_net.py --num-gpus 3 \
+python tools/train_net.py --num-gpus ${NUM_GPUS} \
     --config-file configs/RFS/split${SPLIT}/${SHOT}shot_GPB_PFB_proloss.yml \
     --opts MODEL.WEIGHTS ${OUTPUT_ROOT}/faster_rcnn_R_101_FPN_all${SPLIT}/model_surgery.pth \
            OUTPUT_DIR ${OUTPUT_ROOT}/split${SPLIT}_${SHOT}shot_GPB_PFB_proloss ${FINE_EXTRA}

--- a/scripts/train_fsod.sh
+++ b/scripts/train_fsod.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+# Simple training script for the FSOD dataset
+# Usage: bash scripts/train_fsod.sh [SPLIT] [SHOT] [OUTPUT_ROOT] [BASE_ITERS] [FINE_ITERS]
+# BASE_ITERS and FINE_ITERS optionally override SOLVER.MAX_ITER for the two stages
+
+SPLIT=${1:-1}
+SHOT=${2:-10}
+OUTPUT_ROOT=${3:-./checkpoints/fsod}
+BASE_ITERS=${4:-0}
+FINE_ITERS=${5:-0}
+
+FINE_EXTRA=""
+if [ "$FINE_ITERS" -gt 0 ]; then
+    FINE_EXTRA="SOLVER.MAX_ITER ${FINE_ITERS}"
+fi
+
+# Stage 1: train the base detector
+BASE_EXTRA=""
+if [ "$BASE_ITERS" -gt 0 ]; then
+    BASE_EXTRA="SOLVER.MAX_ITER ${BASE_ITERS}"
+fi
+
+python tools/train_net.py --num-gpus 3 \
+    --config-file configs/RFS/base-training/R101_FPN_base_training_split${SPLIT}.yml \
+    --opts OUTPUT_DIR ${OUTPUT_ROOT}/faster_rcnn_R_101_FPN_base${SPLIT} ${BASE_EXTRA}
+
+# Initialize novel-class weights
+python tools/ckpt_surgery.py \
+    --src1 ${OUTPUT_ROOT}/faster_rcnn_R_101_FPN_base${SPLIT}/model_final.pth \
+    --method randinit \
+    --save-dir ${OUTPUT_ROOT}/faster_rcnn_R_101_FPN_all${SPLIT}
+
+# Stage 2: fine-tune on novel data
+python tools/train_net.py --num-gpus 3 \
+    --config-file configs/RFS/split${SPLIT}/${SHOT}shot_GPB_PFB_proloss.yml \
+    --opts MODEL.WEIGHTS ${OUTPUT_ROOT}/faster_rcnn_R_101_FPN_all${SPLIT}/model_surgery.pth \
+           OUTPUT_DIR ${OUTPUT_ROOT}/split${SPLIT}_${SHOT}shot_GPB_PFB_proloss ${FINE_EXTRA}
+

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,15 @@ import os
 import shutil
 from setuptools import find_packages, setup
 from typing import List
-import torch
+
+try:
+    import torch
+except ImportError as e:
+    raise RuntimeError(
+        "PyTorch must be installed before running setup.py. "
+        "Please install PyTorch and torchvision, then retry."
+    ) from e
+
 from torch.utils.cpp_extension import CUDA_HOME, CppExtension, CUDAExtension
 
 torch_ver = [int(x) for x in torch.__version__.split(".")[:2]]

--- a/tools/test_net.py
+++ b/tools/test_net.py
@@ -130,6 +130,8 @@ def setup(args):
     cfg = get_cfg()
     cfg.merge_from_file(args.config_file)
     cfg.merge_from_list(args.opts or [])
+    if args.show_config:
+        print("Merged config:\n" + cfg.dump())
     cfg.freeze()
     set_global_cfg(cfg)
     default_setup(cfg, args)

--- a/tools/test_net.py
+++ b/tools/test_net.py
@@ -129,7 +129,7 @@ def setup(args):
     """
     cfg = get_cfg()
     cfg.merge_from_file(args.config_file)
-    cfg.merge_from_list(args.opts)
+    cfg.merge_from_list(args.opts or [])
     cfg.freeze()
     set_global_cfg(cfg)
     default_setup(cfg, args)

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -91,6 +91,8 @@ def setup(args):
     cfg = get_cfg()
     cfg.merge_from_file(args.config_file)
     cfg.merge_from_list(args.opts or [])
+    if args.show_config:
+        print("Merged config:\n" + cfg.dump())
     cfg.freeze()
     set_global_cfg(cfg)
     default_setup(cfg, args)

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -28,13 +28,7 @@ from fsdet.engine import (
     default_setup,
     launch,
 )
-from fsdet.evaluation import (
-    COCOEvaluator,
-    DatasetEvaluators,
-    LVISEvaluator,
-    PascalVOCDetectionEvaluator,
-    verify_results,
-)
+from fsdet.evaluation import DatasetEvaluators, verify_results
 
 # from fsdet.data.dataset_mapper import AlbumentationMapper
 
@@ -59,11 +53,17 @@ class Trainer(DefaultTrainer):
             output_folder = os.path.join(cfg.OUTPUT_DIR, "inference")
         evaluator_list = []
         evaluator_type = MetadataCatalog.get(dataset_name).evaluator_type
-        if evaluator_type == "coco":
+        # Import evaluators lazily so training can run without COCO/LVIS support
+        from fsdet.evaluation import (
+            COCOEvaluator,
+            PascalVOCDetectionEvaluator,
+            LVISEvaluator,
+        )
+        if evaluator_type == "coco" and COCOEvaluator is not None:
             evaluator_list.append(COCOEvaluator(dataset_name, cfg, True, output_folder))
         if evaluator_type == "pascal_voc":
             return PascalVOCDetectionEvaluator(dataset_name)
-        if evaluator_type == "lvis":
+        if evaluator_type == "lvis" and LVISEvaluator is not None:
             return LVISEvaluator(dataset_name, cfg, True, output_folder)
         if evaluator_type == "rfs":
             return RFSDetectionEvaluator(dataset_name)

--- a/tools/train_net.py
+++ b/tools/train_net.py
@@ -90,7 +90,7 @@ def setup(args):
     """
     cfg = get_cfg()
     cfg.merge_from_file(args.config_file)
-    cfg.merge_from_list(args.opts)
+    cfg.merge_from_list(args.opts or [])
     cfg.freeze()
     set_global_cfg(cfg)
     default_setup(cfg, args)

--- a/tools/visualize_data.py
+++ b/tools/visualize_data.py
@@ -18,7 +18,7 @@ def setup(args):
     cfg = get_cfg()
     if args.config_file:
         cfg.merge_from_file(args.config_file)
-    cfg.merge_from_list(args.opts)
+    cfg.merge_from_list(args.opts or [])
     cfg.freeze()
     return cfg
 

--- a/tools/visualize_data.py
+++ b/tools/visualize_data.py
@@ -19,6 +19,8 @@ def setup(args):
     if args.config_file:
         cfg.merge_from_file(args.config_file)
     cfg.merge_from_list(args.opts or [])
+    if args.show_config:
+        print("Merged config:\n" + cfg.dump())
     cfg.freeze()
     return cfg
 
@@ -34,6 +36,7 @@ def parse_args(in_args=None):
     parser.add_argument("--config-file", default="", metavar="FILE", help="path to config file")
     parser.add_argument("--output-dir", default="./", help="path to output directory")
     parser.add_argument("--show", action="store_true", help="show output in a window")
+    parser.add_argument("--show-config", action="store_true", help="print the final config and exit")
     parser.add_argument(
         "--opts",
         help="Modify config options using the command-line",


### PR DESCRIPTION
## Summary
- gracefully handle missing COCO/LVIS evaluators

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_6849961baf60832aafd1b62930e395d2